### PR TITLE
fixed 'trades undefined' error when exporting

### DIFF
--- a/extension/src/components/TradeHistory/CSVExport.js
+++ b/extension/src/components/TradeHistory/CSVExport.js
@@ -70,7 +70,8 @@ const CSVExport = () => {
       });
 
       csvContent += lines;
-      if (tradesResponse.trades.length === 0 || exportEndTimeUnix <= lastProcessedTradeTime) {
+      if (tradesResponse.more && (
+        tradesResponse.trades.length === 0 || exportEndTimeUnix <= lastProcessedTradeTime)) {
         loadNextChunk(lastProcessedTradeTime, lastProcessedTradeID);
       } else finishExport();
     });

--- a/extension/src/utils/IEconService.js
+++ b/extension/src/utils/IEconService.js
@@ -126,6 +126,7 @@ const getTradeHistory = (
                   trades,
                   lastTradeID: trades[trades.length - 1].tradeid,
                   lastTradeTime: trades[trades.length - 1].time_init,
+                  more: body.response.more,
                 });
               }).catch((err) => {
                 console.log(err);


### PR DESCRIPTION
I wanted to export my trade history and had the "trades undefined" error, this pr fixes this. Would be great if you can check this out and confirm that this change doesnt break anything.