### PR TITLE
Fix for 'Run CT, Run' sticker name with comma

### DIFF
--- a/extension/src/utils/utilsModular.js
+++ b/extension/src/utils/utilsModular.js
@@ -323,6 +323,10 @@ const handleStickerNamesWithCommas = (names) => {
       namesModified.push('Hi, My Game Is');
       nameWithCommaFound = true;
       i += 1;
+    } else if (name === 'Run CT' && names[i + 1] === 'Run') {
+      namesModified.push('Run CT, Run');
+      nameWithCommaFound = true;
+      i += 1;
     } else if (names[i + 1] === 'Champion) | Antwerp 2022') {
       namesModified.push(`${name}, Champion) | Antwerp 2022`);
       nameWithCommaFound = true;


### PR DESCRIPTION
I didnt test it, but should work 

![image](https://user-images.githubusercontent.com/35603466/193568574-22cc8b4f-e984-4ddb-b96e-d243614255f9.png)

![image](https://user-images.githubusercontent.com/35603466/193568593-0f4ec7e6-bd94-415a-976f-a62b3d010249.png)
