### PR TITLE
Manifest: name and logo file update

### DIFF
--- a/site/public/manifest.json
+++ b/site/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "CSGO Trader",
+  "name": "CSGO Trader - Steam Trading Enhancer",
   "icons": [
     {
       "src": "favicon.ico",
@@ -8,12 +8,12 @@
       "type": "image/x-icon"
     },
     {
-      "src": "logo192.png",
+      "src": "cstlogo192.png",
       "type": "image/png",
       "sizes": "192x192"
     },
     {
-      "src": "logo512.png",
+      "src": "cstlogo512.png",
       "type": "image/png",
       "sizes": "512x512"
     }


### PR DESCRIPTION
Visiting csgotrader.app, I noticed two manifest errors in the console:
![Screenshot_447](https://user-images.githubusercontent.com/21990230/235364331-27dd7522-75f6-41c1-98e0-d5bd3e46a437.png)

This PR aims to fix the logo's file path mentioned in the manifest as well as the generic name from the initial setup.