### PR TITLE
added secondary confirmation option for quick and instant sell

### DIFF
--- a/extension/src/components/Options/Categories/Inventory.js
+++ b/extension/src/components/Options/Categories/Inventory.js
@@ -69,6 +69,12 @@ const inventory = () => {
         description="Adds Instant Sell and Quick Sell buttons by the normal Sell button for the active inventory item"
       />
       <Row
+        name="Safe Instant and Quick sell"
+        id="safeInstantQuickSell"
+        type="flipSwitchStorage"
+        description="Instant and Quick sell actions require another layer of confirmation via a popup (to prevent misclicks)"
+      />
+      <Row
         name="Show duplicate count"
         id="inventoryShowDuplicateCount"
         type="flipSwitchStorage"

--- a/extension/src/contentScripts/steam/inventory.js
+++ b/extension/src/contentScripts/steam/inventory.js
@@ -917,7 +917,7 @@ const addRightSideElements = () => {
       // adds "starting at" and sales volume to everyone's inventory
       if (!isOwnInventory()) addStartingAtPrice(item.appid, item.market_hash_name);
       else if (item.marketable) { // adds quick and instant sell buttons
-        chrome.storage.local.get(['inventoryInstantQuickButtons'], ({ inventoryInstantQuickButtons }) => {
+        chrome.storage.local.get(['inventoryInstantQuickButtons', 'safeInstantQuickSell'], ({ inventoryInstantQuickButtons, safeInstantQuickSell }) => {
           if (inventoryInstantQuickButtons) {
             document.querySelectorAll('.item_market_actions').forEach((marketActions) => {
               marketActions.insertAdjacentHTML(
@@ -938,6 +938,8 @@ const addRightSideElements = () => {
 
               marketActions.querySelectorAll('.marketActionInstantSell').forEach((instantSellButton) => {
                 instantSellButton.addEventListener('click', () => {
+                  if (safeInstantQuickSell && !confirm('Are you sure you want to Instant Sell this item?')) return;
+
                   getHighestBuyOrder(
                     item.appid,
                     item.market_hash_name,
@@ -973,6 +975,8 @@ const addRightSideElements = () => {
 
               marketActions.querySelectorAll('.marketActionQuickSell').forEach((quickSellButton) => {
                 quickSellButton.addEventListener('click', () => {
+                  if (safeInstantQuickSell && !confirm('Are you sure you want to Quick Sell this item?')) return;
+
                   getLowestListingPrice(
                     item.appid,
                     item.market_hash_name,

--- a/extension/src/contentScripts/steam/inventory.js
+++ b/extension/src/contentScripts/steam/inventory.js
@@ -938,7 +938,7 @@ const addRightSideElements = () => {
 
               marketActions.querySelectorAll('.marketActionInstantSell').forEach((instantSellButton) => {
                 instantSellButton.addEventListener('click', () => {
-                  if (safeInstantQuickSell && !confirm('Are you sure you want to Instant Sell this item?')) return;
+                  if (safeInstantQuickSell && !window.confirm('Are you sure you want to Instant Sell this item?')) return; // eslint-disable-line no-alert
 
                   getHighestBuyOrder(
                     item.appid,
@@ -975,7 +975,7 @@ const addRightSideElements = () => {
 
               marketActions.querySelectorAll('.marketActionQuickSell').forEach((quickSellButton) => {
                 quickSellButton.addEventListener('click', () => {
-                  if (safeInstantQuickSell && !confirm('Are you sure you want to Quick Sell this item?')) return;
+                  if (safeInstantQuickSell && !window.confirm('Are you sure you want to Quick Sell this item?')) return; // eslint-disable-line no-alert
 
                   getLowestListingPrice(
                     item.appid,

--- a/extension/src/utils/static/storageKeys.js
+++ b/extension/src/utils/static/storageKeys.js
@@ -149,6 +149,7 @@ const storageKeys = {
   linkFilterOff: false,
   marketListingsInstantBuy: true,
   inventoryInstantQuickButtons: true,
+  safeInstantQuickSell: false,
   marketMainPagePricesAutoLoad: true,
   marketHistoryEventsToShow: 50,
   marketShowFloatValuesOnly: false,


### PR DESCRIPTION
- Adds a toggle option in Inventory settings called "Safe Instant and Quick sell"

- When toggled on and Instant or Quick sell is clicked for an item, a secondary confirmation to sell the item will appear via the `confirm()` js function