### PR TITLE
updated chrome web store urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ For more information about each part you can read the corresponding .md files.
 Extension Install
 --------------
 Get it from your browser's marketplace:
-- <a target="_blank" href="https://chrome.google.com/webstore/detail/csgo-trader/kaibcgikagnkfgjnibflebpldakfhfih/">Chrome Web Store</a> (for Chromium based browsers, Chrome, Brave, Opera, etc.)
+- <a target="_blank" href="https://chromewebstore.google.com/detail/cs2-trader-steam-trading/kaibcgikagnkfgjnibflebpldakfhfih">Chrome Web Store</a> (for Chromium based browsers, Chrome, Brave, Opera, etc.)
 - <a target="_blank" href="https://addons.mozilla.org/en-US/firefox/addon/csgo-trader-steam-trading/">Firefox Add-ons</a>
 - <a target="_blank" href="https://microsoftedge.microsoft.com/addons/detail/emcdnkamomgiafjejbhdpcfgbeeimpdb">Microsoft Edge Addons</a>
 - To install without a platform or for development, find instructions here: <a target="_blank" href="https://csgotrader.app/faq/#installmanual">csgotrader.app/faq/#installmanual</a>

--- a/site/src/components/Footer/Footer.js
+++ b/site/src/components/Footer/Footer.js
@@ -16,7 +16,7 @@ const footer = () => {
             <div>
                 <BrandIcon link='https://github.com/gergelyszabo94/csgo-trader-extension' brand='github'/>
                 <BrandIcon link='https://steamcommunity.com/groups/csgotraderextension' brand='steam'/>
-                <BrandIcon link='https://chrome.google.com/webstore/detail/csgo-trader-steam-trading/kaibcgikagnkfgjnibflebpldakfhfih' brand='chrome'/>
+                <BrandIcon link='https://chromewebstore.google.com/detail/cs2-trader-steam-trading/kaibcgikagnkfgjnibflebpldakfhfih' brand='chrome'/>
                 <BrandIcon link='https://addons.mozilla.org/en-US/firefox/addon/csgo-trader-steam-trading/' brand='firefox'/>
                 <BrandIcon link='https://microsoftedge.microsoft.com/addons/detail/emcdnkamomgiafjejbhdpcfgbeeimpdb' brand='edge'/>
                 <BrandIcon link='https://www.youtube.com/channel/UCkDNavvHkCFHFCZ2bmG4zzw' brand='youtube'/>

--- a/site/src/containers/Faq/Faq.js
+++ b/site/src/containers/Faq/Faq.js
@@ -66,7 +66,7 @@ const faq = (props) => {
                     <p>
                         Installing from a distribution platform is the recommended way of installing the extension as it's the easiest way and guarantees that you will receive updates automatically.
                         The extension is available in the
-                        <NewTabLink to='https://chrome.google.com/webstore/detail/csgo-trader-steam-trading/kaibcgikagnkfgjnibflebpldakfhfih'> Chrome Web Store </NewTabLink>
+                        <NewTabLink to='https://chromewebstore.google.com/detail/cs2-trader-steam-trading/kaibcgikagnkfgjnibflebpldakfhfih'> Chrome Web Store </NewTabLink>
                         at
                         <NewTabLink to='https://microsoftedge.microsoft.com/addons/detail/emcdnkamomgiafjejbhdpcfgbeeimpdb'> Microsoft Edge Addons </NewTabLink>
                         and at
@@ -167,7 +167,7 @@ const faq = (props) => {
                 <Question title='How can I support it?'>
                     <p>
                         Leaving a positive review or rating in the
-                        <NewTabLink to='https://chrome.google.com/webstore/detail/csgo-trader-steam-trading/kaibcgikagnkfgjnibflebpldakfhfih'> Chrome Web Store </NewTabLink>
+                        <NewTabLink to='https://chromewebstore.google.com/detail/cs2-trader-steam-trading/kaibcgikagnkfgjnibflebpldakfhfih'> Chrome Web Store </NewTabLink>
                         or at
                         <NewTabLink to='https://addons.mozilla.org/en-US/firefox/addon/csgo-trader-steam-trading/'> Mozilla Addons </NewTabLink>
                         helps others find it and motivates me to keep working on it.

--- a/site/src/containers/Home/Home.js
+++ b/site/src/containers/Home/Home.js
@@ -46,7 +46,7 @@ const home = (props) => {
         <h2>Install</h2>
         <p>
           The extension is available in the
-          <NewTabLink to='https://chrome.google.com/webstore/detail/csgo-trader/kaibcgikagnkfgjnibflebpldakfhfih/'> Chrome Web Store </NewTabLink>
+          <NewTabLink to='https://chromewebstore.google.com/detail/cs2-trader-steam-trading/kaibcgikagnkfgjnibflebpldakfhfih'> Chrome Web Store </NewTabLink>
           at
           <NewTabLink to='https://microsoftedge.microsoft.com/addons/detail/emcdnkamomgiafjejbhdpcfgbeeimpdb'> Microsoft Edge Addons </NewTabLink>
           and at
@@ -60,7 +60,7 @@ const home = (props) => {
         Get it from your browser's marketplace:
         <p align='center'>
           <PlatformIcon
-            link='https://chrome.google.com/webstore/detail/csgo-trader/kaibcgikagnkfgjnibflebpldakfhfih/'
+            link='https://chromewebstore.google.com/detail/cs2-trader-steam-trading/kaibcgikagnkfgjnibflebpldakfhfih'
             img='/img/chrome.png'
             title='Get it for Chrome from Chrome Web Store'
           />


### PR DESCRIPTION
Updated all the URLs for chrome web store. Following the domain and extension rename from csgo to cs2.

Let me know if there are any issues or any updates are required.

Issue: On https://csgotrader.app/ chrome webstore URL is not working correctly if clicked from that page. For some reason, that same URL is working if copy pasted directly into the browser.