### PR TITLE
fix: updated cs:go weapon cases priceempire link

### DIFF
--- a/extension/src/utils/utilsModular.js
+++ b/extension/src/utils/utilsModular.js
@@ -1025,6 +1025,8 @@ const getPricempireLink = (itemType, itemName, dopplerType, condition) => {
           itemName
             .replace(/\s+/g, '-')
             .replace(/[^\w-]+/g, '')
+            // PriceEmpire uses csgo instead of cs:go now for cs:go weapon cases
+            .replace('CS:GO', 'CSGO')
             .toLowerCase()}`;
       case 'custom_player':
         return `cs2-items/agent/${


### PR DESCRIPTION
PriceEmpire links for CS:GO Weapon Cases 1, 2, 3 are updated to use csgo instead of cs:go. This affects the inventory and trade offers page.

Changes made only affect the "cs2-items/container/*" urls, and as for testing, nothing else breaks.