### PR TITLE
[codex] Fix CS2 tradelock timer parsing

### DIFF
--- a/extension/src/contentScripts/steam/inventory.js
+++ b/extension/src/contentScripts/steam/inventory.js
@@ -18,7 +18,9 @@ import {
   getItemMarketLink, isDopplerInName, getCollection,
   reloadPageOnExtensionUpdate,
 } from 'utils/simpleUtils';
-import { getShortDate, dateToISODisplay, prettyTimeAgo } from 'utils/dateTime';
+import {
+  getShortDate, dateToISODisplay, prettyTimeAgo, getTradabilityInfo,
+} from 'utils/dateTime';
 import {
   stattrak, starChar, souvenir, stattrakPretty, genericMarketLink,
 } from 'utils/static/simpleStrings';
@@ -328,29 +330,9 @@ const getCSGOInventoryDataFromPage = () => new Promise((resolve) => {
               inventoryTotal += parseFloat(price.price);
             } else price = { price: '', display: '' };
 
-            // english only since it would be a ton of work to parse the localized strings
-            if (item.description.tradable === 0 && item.description.marketable === 0) {
-              if (item.description.owner_descriptions) {
-                item.description.owner_descriptions.forEach((description) => {
-                  if (/\d/.test(description.value)) {
-                    try {
-                      if (description.value.includes(('transferred until'))) {
-                        tradability = description.value.split('transferred until ')[1].replace(/[()]/g, '');
-                      } else if (description.value.includes('Tradable/Marketable After')) {
-                        tradability = description.value.split('Tradable/Marketable After ')[1].replace(/[()]/g, '');
-                      }
-                    } catch (e) {
-                      console.log(e);
-                      tradability = description.value;
-                    }
-                  }
-                });
-                tradabilityShort = getShortDate(tradability);
-              } else {
-                tradability = 'Not Tradable';
-                tradabilityShort = '';
-              }
-            }
+            const tradabilityInfo = getTradabilityInfo(item.description.tradable, item.description.owner_descriptions);
+            tradability = tradabilityInfo.tradability;
+            tradabilityShort = tradabilityInfo.tradabilityShort;
 
             itemsPropertiesToReturn.push({
               description: item.description,

--- a/extension/src/contentScripts/steam/inventory.js
+++ b/extension/src/contentScripts/steam/inventory.js
@@ -231,6 +231,24 @@ const getVisibleItemInfoText = () => {
   return textOfDescriptors;
 };
 
+const addOrUpdatePerItemDate = (itemElement, item) => {
+  if (!itemElement || item.tradability === 'Tradable' || item.tradability === 'Not Tradable') return;
+
+  const itemDateElement = itemElement.querySelector('.perItemDate');
+  if (itemDateElement) {
+    itemDateElement.innerText = item.tradabilityShort;
+    itemDateElement.classList.add('not_tradable');
+    itemDateElement.classList.remove('tradable');
+    return;
+  }
+
+  const contrastingLookClass = showContrastingLook ? 'contrastingBackground' : '';
+  itemElement.insertAdjacentHTML(
+    'beforeend',
+    DOMPurify.sanitize(`<div class="perItemDate ${contrastingLookClass} not_tradable">${item.tradabilityShort}</div>`),
+  );
+};
+
 const syncActiveItemTradabilityFromPage = (item) => {
   if (!item || item.tradability !== 'Not Tradable') return;
 
@@ -240,13 +258,12 @@ const syncActiveItemTradabilityFromPage = (item) => {
   item.tradability = tradeDate;
   item.tradabilityShort = getShortDate(tradeDate);
 
-  const itemElement = findElementByIDs(item.appid, item.contextid, item.assetid, 'inventory');
-  const itemDateElement = itemElement ? itemElement.querySelector('.perItemDate') : null;
-  if (itemDateElement) {
-    itemDateElement.innerText = item.tradabilityShort;
-    itemDateElement.classList.add('not_tradable');
-    itemDateElement.classList.remove('tradable');
-  }
+  chrome.storage.local.get(['showTradeLockIndicatorInInventories'], ({ showTradeLockIndicatorInInventories }) => {
+    if (!showTradeLockIndicatorInInventories) return;
+
+    const itemElement = findElementByIDs(item.appid, item.contextid, item.assetid, 'inventory');
+    addOrUpdatePerItemDate(itemElement, item);
+  });
 };
 
 const getItemInfoFromPage = (appID, contextID) => {
@@ -1320,13 +1337,7 @@ const addPerItemInfo = (appID) => {
 
           if (showTradeLockIndicatorInInventories) {
             // adds tradability indicator
-            if (item.tradability !== 'Tradable' && item.tradability !== 'Not Tradable') {
-              const contrastingLookClass = showContrastingLook ? 'contrastingBackground' : '';
-              itemElement.insertAdjacentHTML(
-                'beforeend',
-                DOMPurify.sanitize(`<div class="perItemDate ${contrastingLookClass} not_tradable">${item.tradabilityShort}</div>`),
-              );
-            }
+            addOrUpdatePerItemDate(itemElement, item);
           }
 
           if (appID === steamApps.CSGO.appID) {

--- a/extension/src/contentScripts/steam/inventory.js
+++ b/extension/src/contentScripts/steam/inventory.js
@@ -330,7 +330,11 @@ const getCSGOInventoryDataFromPage = () => new Promise((resolve) => {
               inventoryTotal += parseFloat(price.price);
             } else price = { price: '', display: '' };
 
-            const tradabilityInfo = getTradabilityInfo(item.description.tradable, item.description.owner_descriptions);
+            const tradabilityInfo = getTradabilityInfo(
+              item.description.tradable,
+              item.description.owner_descriptions,
+              item.description.descriptions,
+            );
             tradability = tradabilityInfo.tradability;
             tradabilityShort = tradabilityInfo.tradabilityShort;
 

--- a/extension/src/contentScripts/steam/inventory.js
+++ b/extension/src/contentScripts/steam/inventory.js
@@ -19,7 +19,7 @@ import {
   reloadPageOnExtensionUpdate,
 } from 'utils/simpleUtils';
 import {
-  getShortDate, dateToISODisplay, prettyTimeAgo, getTradabilityInfo,
+  getShortDate, dateToISODisplay, prettyTimeAgo, getTradabilityInfo, getTradeDateFromText,
 } from 'utils/dateTime';
 import {
   stattrak, starChar, souvenir, stattrakPretty, genericMarketLink,
@@ -213,6 +213,39 @@ const countDown = (dateToCountDownTo) => {
     clearInterval(countDownID);
     countingDown = false;
     countDown(dateToCountDownTo);
+  }
+};
+
+const getVisibleItemInfoText = () => {
+  let textOfDescriptors = '';
+  document.querySelectorAll('.inventory_page_right div[data-featuretarget="iteminfo"]:not([style*="display: none"])').forEach((itemInfo) => {
+    textOfDescriptors = itemInfo.textContent;
+  });
+
+  if (textOfDescriptors) return textOfDescriptors;
+
+  document.querySelectorAll('div[data-featuretarget="iteminfo"][style]:not([style*="display: none"])').forEach((itemInfo) => {
+    textOfDescriptors = itemInfo.textContent;
+  });
+
+  return textOfDescriptors;
+};
+
+const syncActiveItemTradabilityFromPage = (item) => {
+  if (!item || item.tradability !== 'Not Tradable') return;
+
+  const tradeDate = getTradeDateFromText(getVisibleItemInfoText());
+  if (!tradeDate) return;
+
+  item.tradability = tradeDate;
+  item.tradabilityShort = getShortDate(tradeDate);
+
+  const itemElement = findElementByIDs(item.appid, item.contextid, item.assetid, 'inventory');
+  const itemDateElement = itemElement ? itemElement.querySelector('.perItemDate') : null;
+  if (itemDateElement) {
+    itemDateElement.innerText = item.tradabilityShort;
+    itemDateElement.classList.add('not_tradable');
+    itemDateElement.classList.remove('tradable');
   }
 };
 
@@ -709,11 +742,7 @@ const addRightSideElements = (reRun) => {
     ) {
       if (item && showAllExteriorsMenu) {
         // it takes the visible item and checks if the collection includes souvenirs
-        let textOfDescriptors = '';
-        document.querySelectorAll('div[data-featuretarget="iteminfo"][style]:not([style*="display: none"])').forEach((itemInfo) => {
-          textOfDescriptors = itemInfo.textContent;
-        });
-
+        const textOfDescriptors = getVisibleItemInfoText();
         const thereSouvenirForThisItem = souvenirExists(textOfDescriptors);
 
         let weaponName = '';
@@ -813,6 +842,8 @@ const addRightSideElements = (reRun) => {
       if (activeInventoryAppID === steamApps.CSGO.appID
         || activeInventoryAppID === steamApps.DOTA2.appID
         || activeInventoryAppID === steamApps.TF2.appID) {
+        syncActiveItemTradabilityFromPage(item);
+
         if (activeInventoryAppID === steamApps.CSGO.appID) {
           // repositions stickers and charms
           if ((item.stickers !== undefined && item.stickers.length !== 0)

--- a/extension/src/utils/dateTime.js
+++ b/extension/src/utils/dateTime.js
@@ -25,10 +25,56 @@ const prettyTimeAgo = (unixTimestamp) => {
   return prettyString;
 };
 
+const tradeDateRegex = new RegExp([
+  String.raw`(?:Tradable(?:/Marketable)? After|transferred until)\s*:?\s*(`,
+  String.raw`\d{1,2}/\d{1,2}/\d{4},?\s+\d{1,2}:\d{2}:\d{2}\s*(?:AM|PM)?`,
+  '|',
+  String.raw`[A-Za-z]{3,9}\s+\d{1,2},\s+\d{4},?\s*(?:\(?\d{1,2}:\d{2}:\d{2}\)?\s*(?:AM|PM)?\s*(?:GMT)?)?`,
+  ')',
+].join(''), 'i');
+
+const getDescriptionValue = (description) => {
+  if (typeof description === 'string') return description;
+  if (description && description.value) return description.value;
+  return '';
+};
+
+const getTradeDateFromDescription = (description) => {
+  const text = getDescriptionValue(description)
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/&nbsp;|&#160;/gi, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  if (!/\d/.test(text)) return null;
+
+  const tradeDateMatch = text.match(tradeDateRegex);
+  if (!tradeDateMatch) return null;
+
+  const tradeDate = tradeDateMatch[1].replace(/[()]/g, '').replace(/\s+/g, ' ').trim();
+  if (Number.isNaN(new Date(tradeDate).getTime())) return null;
+
+  return tradeDate;
+};
+
+const getTradeDateFromDescriptions = (ownerDescriptions) => {
+  if (!ownerDescriptions) return null;
+
+  for (const description of ownerDescriptions) {
+    const tradeDate = getTradeDateFromDescription(description);
+    if (tradeDate) return tradeDate;
+  }
+
+  return null;
+};
+
 const getShortDate = (tradabibilityDate) => {
   if (tradabibilityDate === 'Tradable' || tradabibilityDate === '') return 'T';
+  if (!tradabibilityDate) return '';
   const now = new Date().getTime();
-  const distance = new Date(tradabibilityDate) - now;
+  const tradabilityTime = new Date(tradabibilityDate).getTime();
+  if (Number.isNaN(tradabilityTime)) return '';
+  const distance = tradabilityTime - now;
   if (distance <= 0) return 'T';
 
   const days = Math.floor(distance / (1000 * 60 * 60 * 24));
@@ -48,4 +94,28 @@ const getShortDate = (tradabibilityDate) => {
   return `${days}d`;
 };
 
-export { dateToISODisplay, prettyTimeAgo, getShortDate };
+const getTradabilityInfo = (tradable, ownerDescriptions) => {
+  if (tradable !== 0) {
+    return {
+      tradability: 'Tradable',
+      tradabilityShort: 'T',
+    };
+  }
+
+  const tradeDate = getTradeDateFromDescriptions(ownerDescriptions);
+  if (tradeDate) {
+    return {
+      tradability: tradeDate,
+      tradabilityShort: getShortDate(tradeDate),
+    };
+  }
+
+  return {
+    tradability: 'Not Tradable',
+    tradabilityShort: '',
+  };
+};
+
+export {
+  dateToISODisplay, prettyTimeAgo, getShortDate, getTradabilityInfo,
+};

--- a/extension/src/utils/dateTime.js
+++ b/extension/src/utils/dateTime.js
@@ -39,22 +39,26 @@ const getDescriptionValue = (description) => {
   return '';
 };
 
-const getTradeDateFromDescription = (description) => {
-  const text = getDescriptionValue(description)
+const getTradeDateFromText = (text) => {
+  const cleanText = String(text || '')
     .replace(/<[^>]*>/g, ' ')
     .replace(/&nbsp;|&#160;/gi, ' ')
     .replace(/\s+/g, ' ')
     .trim();
 
-  if (!/\d/.test(text)) return null;
+  if (!/\d/.test(cleanText)) return null;
 
-  const tradeDateMatch = text.match(tradeDateRegex);
+  const tradeDateMatch = cleanText.match(tradeDateRegex);
   if (!tradeDateMatch) return null;
 
   const tradeDate = tradeDateMatch[1].replace(/[()]/g, '').replace(/\s+/g, ' ').trim();
   if (Number.isNaN(new Date(tradeDate).getTime())) return null;
 
   return tradeDate;
+};
+
+const getTradeDateFromDescription = (description) => {
+  return getTradeDateFromText(getDescriptionValue(description));
 };
 
 const getTradeDateFromDescriptions = (descriptions) => {
@@ -118,5 +122,5 @@ const getTradabilityInfo = (tradable, ownerDescriptions, descriptions) => {
 };
 
 export {
-  dateToISODisplay, prettyTimeAgo, getShortDate, getTradabilityInfo,
+  dateToISODisplay, prettyTimeAgo, getShortDate, getTradabilityInfo, getTradeDateFromText,
 };

--- a/extension/src/utils/dateTime.js
+++ b/extension/src/utils/dateTime.js
@@ -57,10 +57,10 @@ const getTradeDateFromDescription = (description) => {
   return tradeDate;
 };
 
-const getTradeDateFromDescriptions = (ownerDescriptions) => {
-  if (!ownerDescriptions) return null;
+const getTradeDateFromDescriptions = (descriptions) => {
+  if (!descriptions) return null;
 
-  for (const description of ownerDescriptions) {
+  for (const description of descriptions) {
     const tradeDate = getTradeDateFromDescription(description);
     if (tradeDate) return tradeDate;
   }
@@ -94,7 +94,7 @@ const getShortDate = (tradabibilityDate) => {
   return `${days}d`;
 };
 
-const getTradabilityInfo = (tradable, ownerDescriptions) => {
+const getTradabilityInfo = (tradable, ownerDescriptions, descriptions) => {
   if (tradable !== 0) {
     return {
       tradability: 'Tradable',
@@ -102,7 +102,8 @@ const getTradabilityInfo = (tradable, ownerDescriptions) => {
     };
   }
 
-  const tradeDate = getTradeDateFromDescriptions(ownerDescriptions);
+  const tradeDate = getTradeDateFromDescriptions(ownerDescriptions)
+    || getTradeDateFromDescriptions(descriptions);
   if (tradeDate) {
     return {
       tradability: tradeDate,

--- a/extension/src/utils/getUserInventory.js
+++ b/extension/src/utils/getUserInventory.js
@@ -92,7 +92,11 @@ const getUserCSGOInventory = (steamID, contextID) => new Promise((resolve, rejec
                       inventoryTotal += parseFloat(price.price);
                     } else price = { price: '', display: '' };
 
-                    const tradabilityInfo = getTradabilityInfo(item.tradable, item.owner_descriptions);
+                    const tradabilityInfo = getTradabilityInfo(
+                      item.tradable,
+                      item.owner_descriptions,
+                      item.descriptions,
+                    );
                     tradability = tradabilityInfo.tradability;
                     tradabilityShort = tradabilityInfo.tradabilityShort;
 
@@ -242,7 +246,11 @@ const getUserCSGOInventoryAlternative = (steamID, contextID) => new Promise((res
                     inventoryTotal += parseFloat(price.price);
                   } else price = { price: '', display: '' };
 
-                  const tradabilityInfo = getTradabilityInfo(item.tradable, item.owner_descriptions);
+                  const tradabilityInfo = getTradabilityInfo(
+                    item.tradable,
+                    item.owner_descriptions,
+                    item.descriptions,
+                  );
                   tradability = tradabilityInfo.tradability;
                   tradabilityShort = tradabilityInfo.tradabilityShort;
 
@@ -366,7 +374,11 @@ const getOtherInventory = (appID, steamID) => new Promise((resolve, reject) => {
             const icon = item.icon_url;
             const owner = steamID;
 
-            const tradabilityInfo = getTradabilityInfo(item.tradable, item.owner_descriptions);
+            const tradabilityInfo = getTradabilityInfo(
+              item.tradable,
+              item.owner_descriptions,
+              item.descriptions,
+            );
             tradability = tradabilityInfo.tradability;
             tradabilityShort = tradabilityInfo.tradabilityShort;
 

--- a/extension/src/utils/getUserInventory.js
+++ b/extension/src/utils/getUserInventory.js
@@ -1,7 +1,7 @@
 import { getFloatInfoFromCache } from 'utils/floatCaching';
 import itemTypes from 'utils/static/itemTypes';
 import { getPrice, getStickerPriceTotal } from 'utils/pricing';
-import { getShortDate } from 'utils/dateTime';
+import { getTradabilityInfo } from 'utils/dateTime';
 import {
   getDopplerInfo,
   getExteriorFromTags,
@@ -92,28 +92,9 @@ const getUserCSGOInventory = (steamID, contextID) => new Promise((resolve, rejec
                       inventoryTotal += parseFloat(price.price);
                     } else price = { price: '', display: '' };
 
-                    if (item.tradable === 0 && item.marketable === 0) {
-                      if (item.owner_descriptions) {
-                        item.owner_descriptions.forEach((description) => {
-                          if (/\d/.test(description.value)) {
-                            try {
-                              if (description.value.includes(('transferred until'))) {
-                                tradability = description.value.split('transferred until ')[1].replace(/[()]/g, '');
-                              } else {
-                                tradability = description.value.split('Tradable/Marketable After ')[1].replace(/[()]/g, '');
-                              }
-                            } catch (e) {
-                              console.log(e);
-                              tradability = description.value;
-                            }
-                          }
-                        });
-                        tradabilityShort = getShortDate(tradability);
-                      } else {
-                        tradability = 'Not Tradable';
-                        tradabilityShort = '';
-                      }
-                    }
+                    const tradabilityInfo = getTradabilityInfo(item.tradable, item.owner_descriptions);
+                    tradability = tradabilityInfo.tradability;
+                    tradabilityShort = tradabilityInfo.tradabilityShort;
 
                     itemsPropertiesToReturn.push({
                       name,
@@ -261,28 +242,9 @@ const getUserCSGOInventoryAlternative = (steamID, contextID) => new Promise((res
                     inventoryTotal += parseFloat(price.price);
                   } else price = { price: '', display: '' };
 
-                  if (item.tradable === 0 && item.marketable === 0) {
-                    if (item.owner_descriptions) {
-                      item.owner_descriptions.forEach((description) => {
-                        if (/\d/.test(description.value)) {
-                          try {
-                            if (description.value.includes(('transferred until'))) {
-                              tradability = description.value.split('transferred until ')[1].replace(/[()]/g, '');
-                            } else {
-                              tradability = description.value.split('Tradable/Marketable After ')[1].replace(/[()]/g, '');
-                            }
-                          } catch (e) {
-                            console.log(e);
-                            tradability = description.value;
-                          }
-                        }
-                      });
-                      tradabilityShort = getShortDate(tradability);
-                    } else {
-                      tradability = 'Not Tradable';
-                      tradabilityShort = '';
-                    }
-                  }
+                  const tradabilityInfo = getTradabilityInfo(item.tradable, item.owner_descriptions);
+                  tradability = tradabilityInfo.tradability;
+                  tradabilityShort = tradabilityInfo.tradabilityShort;
 
                   itemsPropertiesToReturn.push({
                     name,
@@ -404,19 +366,9 @@ const getOtherInventory = (appID, steamID) => new Promise((resolve, reject) => {
             const icon = item.icon_url;
             const owner = steamID;
 
-            if (item.tradable === 0 && item.marketable === 0) {
-              if (item.owner_descriptions) {
-                item.owner_descriptions.forEach((description) => {
-                  if (/\d/.test(description.value)) {
-                    tradability = description.value;
-                  }
-                });
-                tradabilityShort = getShortDate(tradability);
-              } else {
-                tradability = 'Not Tradable';
-                tradabilityShort = '';
-              }
-            }
+            const tradabilityInfo = getTradabilityInfo(item.tradable, item.owner_descriptions);
+            tradability = tradabilityInfo.tradability;
+            tradabilityShort = tradabilityInfo.tradabilityShort;
 
             itemsPropertiesToReturn.push({
               name,


### PR DESCRIPTION
Fixes #590

## Summary
- Centralizes Steam inventory tradability parsing in `dateTime.js`.
- Parses trade-related dates from current and previous Steam wording.
- Falls back from `owner_descriptions` to regular `descriptions` when Steam exposes the trade-protection sentence there.
- Adds an active-details DOM fallback for selected inventory items whose visible Steam details contain the trade-lock sentence while the inventory data object still says `Not Tradable`.
- Creates or updates the selected inventory tile's mini trade-lock badge after the DOM fallback discovers a trade date.
- Ignores market-only dates so SCM marketability dates do not shorten the trade timer.
- Guards `getShortDate()` against invalid dates so the UI does not render `NaNd`.

## Root cause
Steam now surfaces trade lock text such as `Tradable After ...`, `Tradable/Marketable After ...`, and trade-protection sentences ending in `transferred until ...`. The previous implementation duplicated exact string splits in multiple inventory paths, so small wording changes or trailing description text could pass a full sentence into `Date`, producing `Invalid Date` and `NaNd` countdown badges.

Some items expose the visible trade-protection sentence through `descriptions` rather than `owner_descriptions`. A later regression case showed another Steam path where the selected item details panel visibly contained `transferred until ...`, but the extension's cached item object still had `Not Tradable`; the selected-item render now parses the visible details text with the same strict trade-date parser before rendering the countdown.

That same late parse used to happen after the per-item tile pass had already skipped `.perItemDate` insertion. The active tile now uses a shared create-or-update helper so the mini badge appears once the selected details panel reveals the trade date, without duplicating badges on repeated selection.

## Validation
- `node ..\probe-dateTime.mjs`
- `npm ci`
- `npm run build`

The parser probe covers owner-description parsing, regular-description fallback, market-only text being ignored, invalid input avoiding `NaNd`, and the active-details DOM-shaped regression text containing `Bookmark and Notify ... transferred until 7/1/2026, 9:00:00 AM Pattern Template: 31`.

The latest build also validates the mini-badge follow-up: parsed trade-lock items still get their normal per-item badge, and DOM-fallback items can create/update the selected tile badge after the date is discovered. The production build passes with the repo's existing bundle-size and Browserslist warnings.